### PR TITLE
#4 Added var in order to control how many cores you use building php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/php_role/tree/develop)
+### Fixed
+- *Use the cores you want building php* @frantsao
 
 ## [1.2.0](https://github.com/idealista/php_role/tree/1.2.0)
 ## [Full Changelog](https://github.com/idealista/php_role/compare/1.1.0...1.2.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ php_ini_configuration_template:
   dest: "{{ php_install_dir }}/lib/php.ini"
 
 # Required libs & Compile options
+php_make_jobs: "{{ ansible_processor_vcpus }}"
 php_required_libs:
   - autoconf
   - automake

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
 - name: PHP | Make
   make:
     chdir: "{{ php_download_dir }}"
-    params: "--jobs={{ ansible_processor_cores }}"
+    params: "--jobs={{ php_make_jobs }}"
 
 - name: PHP | Make install
   make:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Added var in order to control how many cores you use building php with GNU Make.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits
Improve speed building php.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#6 
<!-- Enter any applicable Issues here -->
