### PR TITLE
#26 use curl instead of get_url to download php sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Removed
 ### Changed
+- *[#26](https://github.com/idealista/php_role/issues/26) Use cURL to download the sources* @blalop
 
 ## [3.1.0](https://github.com/idealista/php_role/tree/3.1.0) (2022-02-07)
 ## [Full Changelog](https://github.com/idealista/php_role/compare/3.0.0...3.1.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ php_version: 7.4.25
 php_reinstall: false
 # Available PHP mirrors can be found here: http://php.net/mirrors.php
 php_download_mirror_domain: es1.php.net
+php_download_url: "http://{{ php_download_mirror_domain }}/get/php-{{ php_version }}.tar.gz/from/this/mirror"
 
 # Files & Paths
 php_download_dir: "/usr/src/php_{{ php_version }}"

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -7,12 +7,6 @@ FROM {{ item.image }}
 {% endif %}
 
 # install minimal packages for debian slim images
-{% if item.image == 'debian:bullseye-slim' %}
 RUN apt-get update && \
     apt-get install -y python3 sudo bash ca-certificates iproute2 systemd systemd-sysv python3-pip && \
     apt-get clean
-{% else %}
-RUN apt-get update && \
-    apt-get install -y python sudo bash ca-certificates iproute2 systemd systemd-sysv python-pip && \
-    apt-get clean
-{% endif %}

--- a/molecule/fpm/verify.yml
+++ b/molecule/fpm/verify.yml
@@ -22,7 +22,6 @@
 
   vars_files:
     - ../../defaults/main.yml
-    - ../../vars/main.yml
     - ./group_vars/all.yml
 
   tasks:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,6 +20,7 @@
   command: "curl {{ php_download_url }} -L -o /tmp/php-{{ php_version }}.tar.gz"
   when: not php_installed or php_change_version
   tags: skip_ansible_lint
+  # using curl as get_url receives 503 error - see https://github.com/idealista/php_role/issues/26
 
 - name: PHP | Extract PHP source files
   unarchive:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,10 +11,20 @@
     path: "{{ php_download_dir }}"
     state: directory
 
-- name: PHP | Download and extract PHP source files
+- name: PHP | Ensure curl is installed
+  apt:
+    pkg: curl
+    state: present
+
+- name: PHP | Download PHP source files
+  command: "curl {{ php_download_url }} -L -o /tmp/php-{{ php_version }}.tar.gz"
+  when: not php_installed or php_change_version
+  tags: skip_ansible_lint
+
+- name: PHP | Extract PHP source files
   unarchive:
     remote_src: true
-    src: "{{ php_download_url }}"
+    src: "/tmp/php-{{ php_version }}.tar.gz"
     dest: "{{ php_download_dir }}"
     extra_opts: --strip-components=1
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-
-php_download_url: "http://{{ php_download_mirror_domain }}/get/php-{{ php_version }}.tar.gz/from/this/mirror"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

get_url is not working when downloading PHP sources. See #26 for further context.

### Benefits

Fix the role.

### Possible Drawbacks

We use command instead of get_url.

### Applicable Issues
#26 
