### PR TITLE
Fix checking composer version if the current user is root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Removed
 ### Changed
+- *[#29](https://github.com/idealista/php_role/pull/29) Fix checking composer version if the current user is root* @devnix
 
 ## [3.1.1](https://github.com/idealista/php_role/tree/3.1.1) (2022-03-04)
 ## [Full Changelog](https://github.com/idealista/php_role/compare/3.1.0...3.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Removed
 ### Changed
-- *[#29](https://github.com/idealista/php_role/pull/29) Fix checking composer version if the current user is root* @devnix
 ### Fixed
+- *[#29](https://github.com/idealista/php_role/pull/29) Fix checking composer version if the current user is root* @devnix
 
 ## [3.1.2](https://github.com/idealista/php_role/tree/3.1.3) (2022-05-23)
 ## [Full Changelog](https://github.com/idealista/php_role/compare/3.1.2...3.1.3)

--- a/tasks/composer.yml
+++ b/tasks/composer.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: PHP | Check composer version
-  command: "composer --version"
+  command: "composer --version -n"
   register: php_composer_check
   changed_when: false
   ignore_errors: true


### PR DESCRIPTION
### Description of the Change

Calls `composer --version` with `-n` parameter

### Benefits

Avoids hanging on if the role is executed as root. As it is not recommended, it's only done for checking the composer version, or if it is actually installed, so it should not pose a danger.

### Possible Drawbacks

N/A

### Applicable Issues
N/A
