### PR TITLE
Add target to make module to avoid ` TypeError: 'NoneType' object is not iterable` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Removed
 ### Changed
 
+- *[41](https://github.com/idealista/php_role/pull/41) Add target to make module to avoid `TypeError: 'NoneType' object is not iterable` error* @devnix
+
 ## [3.1.1](https://github.com/idealista/php_role/tree/3.1.1) (2022-03-04)
 ## [Full Changelog](https://github.com/idealista/php_role/compare/3.1.0...3.1.1)
 ### Changed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -55,6 +55,7 @@
   make:
     chdir: "{{ php_download_dir }}"
     params: "--jobs={{ php_make_jobs }}"
+    target: all
 
 - name: PHP | Make install
   make:


### PR DESCRIPTION
In recent versions of Ansible, not having a value for the `target` parameter in the `make` module will throw a non-explanative error. Just calling to the desired target will solve the issue.
![image](https://github.com/idealista/php_role/assets/1777519/4b8a3832-ef4f-4ac0-a45c-6ad81c875b66)
